### PR TITLE
deno.enablePaths working now

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "deno.enable": true,
+  "deno.lint": true,
+  "deno.unstable": false,
+  "deno.enablePaths": ["./server"]
+}

--- a/server/.vscode/settings.json
+++ b/server/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "deno.enable": true,
-  "deno.lint": true,
-  "deno.unstable": false
-}

--- a/src/.vscode/settings.json
+++ b/src/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "deno.enable": false
-}


### PR DESCRIPTION
So I got a response back from the deno team and they said it only works with deno version 1.20.2 or later. 
I made the changes back to just a single settings.json file with the "deno.enablePaths" and now is working on my computer after I upgraded deno. 

So please run command deno upgrade on your computer and this version should work now without having to do multi-root workspaces.