### PR TITLE
Jake/height graphql fix

### DIFF
--- a/src/components/EditableQueryInput.tsx
+++ b/src/components/EditableQueryInput.tsx
@@ -20,7 +20,10 @@ const EditableQueryInput: React.FC<EditableQueryInputPropsInt> = ({
           inner(res[field]);
         }
         if (field === toggled) {
-          res[field] = !res[field];
+          if (toggled === 'feet' || toggled === 'meters') {
+            res['feet'] = !res['feet'];
+            res['meters'] = !res['meters'];
+          } else res[field] = !res[field];
         }
       });
     })(results);

--- a/src/possibleQueries.tsx
+++ b/src/possibleQueries.tsx
@@ -69,7 +69,7 @@ const possibleQueries: allPossibleQueriesType = [
       rocket_type: true,
       description: false,
       diameter: {
-        feet: false,
+        feet: true,
         meters: false,
       },
     },

--- a/src/styles.css
+++ b/src/styles.css
@@ -284,7 +284,6 @@ span {
 .no-toggle:hover {
   cursor: default;
   font-size: 1.2rem;
-  transition: none;
 }
 
 .queryName {


### PR DESCRIPTION
Fixed toggling between height nested subfield options of feet and meters so one is always active and toggling one also toggles the other. This prevents a bug in which a bad GraphQL query can possibly be sent by the user.