### PR TITLE
demo container cache expiry placement change

### DIFF
--- a/src/containers/DemoContainer.tsx
+++ b/src/containers/DemoContainer.tsx
@@ -149,11 +149,6 @@ const DemoContainer: React.FC = () => {
               same query (even with differing fields) come back significantly
               faster once cached.
             </p>
-            <p>
-              Note: This demonstration also takes advantage of the default
-              expiration option in DenoStore to only cache any data for 10
-              seconds.
-            </p>
           </div>
         </div>
       )}
@@ -162,8 +157,12 @@ const DemoContainer: React.FC = () => {
         <p id="current-selected-p">
           {possibleQueries[currSelectionIdx].paragraph}
           <br />
-          <br />
         </p>
+        <p>
+          Note: This demonstration also takes advantage of the default
+          expiration option in DenoStore to only cache any data for 10 seconds.
+        </p>
+        <br />
       </div>
 
       {/* this renders the editable field and dropdown on the left of the Demo section */}


### PR DESCRIPTION
moved note about cache expiration to always render instead of toggle hidden and unhidden with the rest of the explanation